### PR TITLE
Title: Add --limit / -n flag to cap returned data points

### DIFF
--- a/cli/src/av_cli/main.py
+++ b/cli/src/av_cli/main.py
@@ -30,7 +30,15 @@ def _python_type_to_click(param_type):
 
 def _apply_limit(result, limit):
     """Slice the time-series portion of a response to `limit` entries."""
-    if not isinstance(result, dict) or limit is None:
+    if limit is None:
+        return result
+    if isinstance(result, str):
+        lines = result.splitlines()
+        # Keep header row + limit data rows
+        header = lines[0:1]
+        data = lines[1:limit + 1]
+        return '\n'.join(header + data)
+    if not isinstance(result, dict):
         return result
     for key, value in result.items():
         if isinstance(value, dict) and value:

--- a/cli/src/av_cli/main.py
+++ b/cli/src/av_cli/main.py
@@ -28,6 +28,19 @@ def _python_type_to_click(param_type):
 
 
 
+def _apply_limit(result, limit):
+    """Slice the time-series portion of a response to `limit` entries."""
+    if not isinstance(result, dict) or limit is None:
+        return result
+    for key, value in result.items():
+        if isinstance(value, dict) and value:
+            first_val = next(iter(value.values()))
+            if isinstance(first_val, dict):
+                result = {**result, key: dict(list(value.items())[:limit])}
+                break
+    return result
+
+
 def _make_tool_command(func, tool_name):
     """Build a Click command for a single tool function."""
     from av_api.registry import extract_description
@@ -39,7 +52,7 @@ def _make_tool_command(func, tool_name):
         hints = {}
 
     # Build short option flags, skipping conflicts with -h (help) and -k (api-key)
-    used_shorts = {'h', 'k'}
+    used_shorts = {'h', 'k', 'n'}
     short_map = {}
     for pname in sig.parameters:
         for ch in pname.lower():
@@ -52,6 +65,15 @@ def _make_tool_command(func, tool_name):
     has_symbol = 'symbol' in sig.parameters and sig.parameters['symbol'].default is inspect.Parameter.empty
 
     params = []
+    # Add --limit/-n to cap the number of returned data points
+    params.append(
+        click.Option(
+            ['--limit', '-n'],
+            type=click.INT,
+            default=None,
+            help='Maximum number of data points to return.',
+        )
+    )
     # Add --api-key/-k to each subcommand so it can appear after the command name
     params.append(
         click.Option(
@@ -102,6 +124,7 @@ def _make_tool_command(func, tool_name):
         from av_api.context import set_api_key
 
         local_api_key = kwargs.pop('api_key', None)
+        limit = kwargs.pop('limit', None)
         ctx = click.get_current_context()
         api_key = local_api_key or ctx.obj.get('api_key') or os.getenv('ALPHAVANTAGE_API_KEY') or os.getenv('ALPHA_VANTAGE_API_KEY')
         if not api_key:
@@ -117,6 +140,7 @@ def _make_tool_command(func, tool_name):
 
         set_api_key(api_key)
         result = func(**kwargs)
+        result = _apply_limit(result, limit)
 
         if isinstance(result, str):
             click.echo(result)

--- a/cli/tests/test_limit.py
+++ b/cli/tests/test_limit.py
@@ -1,0 +1,48 @@
+from av_cli.main import _apply_limit
+
+
+# 1. limit=None is a no-op
+def test_apply_limit_none_returns_unchanged():
+    data = {"Time Series (Daily)": {"2026-03-18": {"1. open": "252.00"}}}
+    assert _apply_limit(data, None) is data
+
+
+# 2. CSV string: header kept, data rows sliced to limit
+def test_apply_limit_csv_slices_rows():
+    csv = "timestamp,open,high,low,close\n2026-03-18,252,255,249,250\n2026-03-17,251,253,248,249\n2026-03-16,250,252,247,248"
+    result = _apply_limit(csv, 2)
+    lines = result.splitlines()
+    assert lines[0] == "timestamp,open,high,low,close"
+    assert len(lines) == 3  # header + 2 data rows
+
+
+# 3. JSON nested dict: inner time series sliced to limit
+def test_apply_limit_nested_dict_slices_entries():
+    data = {
+        "Meta Data": {"1. Information": "Daily"},
+        "Time Series (Daily)": {
+            "2026-03-18": {"1. open": "252.00"},
+            "2026-03-17": {"1. open": "251.00"},
+            "2026-03-16": {"1. open": "250.00"},
+        },
+    }
+    result = _apply_limit(data, 2)
+    assert len(result["Time Series (Daily)"]) == 2
+
+
+# 4. Non-dict, non-string passthrough (e.g. None or list)
+def test_apply_limit_passthrough_for_unsupported_types():
+    assert _apply_limit(None, 5) is None
+    lst = [1, 2, 3]
+    assert _apply_limit(lst, 5) is lst
+
+
+# 5. CLI integration: --limit flag is wired up to the command
+def test_limit_flag_exists_on_commands():
+    from click.testing import CliRunner
+    from av_cli.main import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["TIME_SERIES_DAILY", "--help"])
+    assert "--limit" in result.output
+    assert "-n" in result.output


### PR DESCRIPTION
- Adds a --limit / -n flag to all CLI commands to cap the number of data points returned
- Fixes _apply_limit to correctly handle CSV string responses (the default format for most endpoints)
- Adds a test suite for _apply_limit covering all response types and CLI flag wiring


Why

Most Alpha Vantage endpoints return large datasets by default. The --limit / -n flag gives users a quick way to preview the most recent N data points without processing the full response.

Testing

Manually tested against TIME_SERIES_DAILY, TIME_SERIES_WEEKLY, TIME_SERIES_MONTHLY, FX_DAILY, FX_WEEKLY,
DIGITAL_CURRENCY_DAILY, and SMA. Also added 5 unit tests covering all code paths, the first test suite in this repo.

Examples
1.

marketdata-cli TIME_SERIES_DAILY AAPL --limit 5

timestamp,open,high,low,close,volume
2026-03-20,247.9750,249.1999,246.0000,247.9900,87139466
2026-03-19,249.4000,251.8300,247.3000,248.9600,34864082
2026-03-18,252.6250,254.9400,249.0000,249.9400,35757874
2026-03-17,252.9550,255.1300,252.1800,254.2300,32361607
2026-03-16,252.1050,253.8850,249.8800,252.8200,32074209
______________________________________________________________________________________________________________________
2. 
marketdata-cli fx_weekly --from_symbol USD --to_symbol EUR -n 5

timestamp,open,high,low,close
2026-03-19,0.87600,0.87620,0.86080,0.86280
2026-03-13,0.86430,0.87630,0.85690,0.87590
2026-03-06,0.84710,0.86720,0.84710,0.86070
2026-02-27,0.84830,0.84980,0.84470,0.84640
2026-02-20,0.84250,0.85160,0.84180,0.84870