### PR TITLE
fix(oauth): allow *.manufact.com redirect hosts + serve path-aware protected-resource metadata

### DIFF
--- a/mcp/lambda_function.py
+++ b/mcp/lambda_function.py
@@ -122,9 +122,18 @@ def lambda_handler(event, context):
 
     # Handle OAuth 2.1 endpoints first (before token validation). The token-minting endpoints
     # (/authorize POST, /token) require the OAuth keys; surface unset keys as a clean 500.
+    # Protected Resource Metadata: RFC 9728 inserts the resource path after the
+    # well-known segment, so for the `/mcp` resource the canonical location is
+    # `/.well-known/oauth-protected-resource/mcp`. Serve both the path-aware
+    # form (spec-correct) and the bare form (backwards-compatible) so clients
+    # and proxies resolve metadata regardless of which they request.
+    protected_resource_paths = (
+        "/.well-known/oauth-protected-resource",
+        "/.well-known/oauth-protected-resource/mcp",
+    )
     if path in (
         "/.well-known/oauth-authorization-server",
-        "/.well-known/oauth-protected-resource",
+        *protected_resource_paths,
         "/authorize",
         "/token",
         "/register",
@@ -132,7 +141,7 @@ def lambda_handler(event, context):
         try:
             if path == "/.well-known/oauth-authorization-server":
                 return handle_metadata_discovery(event)
-            elif path == "/.well-known/oauth-protected-resource":
+            elif path in protected_resource_paths:
                 return handle_protected_resource_metadata(event)
             elif path == "/authorize":
                 return handle_authorization_request(event)

--- a/mcp/src/av_mcp/oauth.py
+++ b/mcp/src/av_mcp/oauth.py
@@ -37,8 +37,9 @@ ALLOWED_REDIRECT_HOSTS = {
     "chatgpt.com",  # ChatGPT connector callback (per-connector path)
     "chat.openai.com",
 }
-# Base domains whose apex AND any subdomain are allowed (https only). Manufact /
-# mcp-use owns *.manufact.com — cloud connector, inspector, preview envs, etc.
+# Base domains whose apex and any subdomain are allowed (https only).
+# mcp-use (Manufact) owns *.manufact.com: cloud connector, inspector, and
+# preview environments all authenticate against this server.
 ALLOWED_REDIRECT_DOMAINS = {
     "manufact.com",
 }

--- a/mcp/src/av_mcp/oauth.py
+++ b/mcp/src/av_mcp/oauth.py
@@ -37,6 +37,11 @@ ALLOWED_REDIRECT_HOSTS = {
     "chatgpt.com",  # ChatGPT connector callback (per-connector path)
     "chat.openai.com",
 }
+# Base domains whose apex AND any subdomain are allowed (https only). Manufact /
+# mcp-use owns *.manufact.com — cloud connector, inspector, preview envs, etc.
+ALLOWED_REDIRECT_DOMAINS = {
+    "manufact.com",
+}
 LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
 
 
@@ -76,10 +81,14 @@ def is_valid_redirect_uri(redirect_uri: str) -> bool:
     # Loopback clients (Claude Code): any port, http or https.
     if host in LOOPBACK_HOSTS:
         return parsed.scheme in ("http", "https")
-    # Everything else must be https against the allowlist.
+    # Everything else must be https against the host allowlist or an allowed domain.
     if parsed.scheme != "https":
         return False
-    return host in ALLOWED_REDIRECT_HOSTS
+    if host in ALLOWED_REDIRECT_HOSTS:
+        return True
+    # Apex or subdomain of an allowed base domain (e.g. *.manufact.com). The
+    # "." prefix on the suffix check prevents look-alikes like "evilmanufact.com".
+    return any(host == domain or host.endswith(f".{domain}") for domain in ALLOWED_REDIRECT_DOMAINS)
 
 
 def verify_pkce_challenge(code_verifier: str, code_challenge: str) -> bool:

--- a/mcp/src/av_mcp/utils.py
+++ b/mcp/src/av_mcp/utils.py
@@ -191,10 +191,14 @@ def create_oauth_error_response(error_dict: dict, status_code: int = 401) -> dic
         f'error_description="{error_dict["error_description"]}"'
     )
     # Point clients at the Protected Resource Metadata document (RFC 9728 / T9).
+    # The resource is the `/mcp` endpoint, so the canonical metadata location is
+    # the path-aware `/.well-known/oauth-protected-resource/mcp` (RFC 9728 inserts
+    # the resource path after the well-known segment). The handler also serves the
+    # bare path for backwards compatibility.
     domain_name = os.environ.get("DOMAIN_NAME")
     if domain_name:
         resource_metadata = (
-            f"https://{domain_name}/.well-known/oauth-protected-resource"
+            f"https://{domain_name}/.well-known/oauth-protected-resource/mcp"
         )
         www_authenticate += f', resource_metadata="{resource_metadata}"'
 

--- a/mcp/tests/test_oauth_tokens.py
+++ b/mcp/tests/test_oauth_tokens.py
@@ -350,8 +350,9 @@ def test_www_authenticate_includes_resource_metadata(monkeypatch):
         {"error": "invalid_token", "error_description": "bad"}, 401
     )
     www = resp["headers"]["WWW-Authenticate"]
+    # Path-aware location for the `/mcp` resource (RFC 9728), not the bare path.
     assert (
-        'resource_metadata="https://mcp.yovy.ai/.well-known/oauth-protected-resource"'
+        'resource_metadata="https://mcp.yovy.ai/.well-known/oauth-protected-resource/mcp"'
         in www
     )
 
@@ -366,6 +367,10 @@ def test_www_authenticate_includes_resource_metadata(monkeypatch):
         "http://127.0.0.1:54999/cb",
         "https://claude.ai/api/mcp/auth_callback",
         "https://chatgpt.com/connector/oauth/abc",
+        # *.manufact.com domain allowlist: apex + any subdomain over https.
+        "https://manufact.com/oauth/callback",
+        "https://inspector.manufact.com/inspector/oauth/callback",
+        "https://foo.bar.manufact.com/cb",
     ],
 )
 def test_redirect_uri_allowed(uri):
@@ -379,6 +384,10 @@ def test_redirect_uri_allowed(uri):
         "http://claude.ai/api/mcp/auth_callback",  # non-loopback http not allowed
         "ftp://localhost/cb",
         "",
+        # manufact.com look-alikes must NOT match the domain allowlist.
+        "https://evilmanufact.com/callback",  # suffix without a "." boundary
+        "https://manufact.com.evil.com/callback",  # different registrable domain
+        "http://manufact.com/callback",  # non-loopback http not allowed
     ],
 )
 def test_redirect_uri_rejected(uri):


### PR DESCRIPTION
## What
Two small OAuth changes so this server works when deployed on mcp-use cloud (Manufact):

**1. Allow `*.manufact.com` as OAuth redirect hosts** (`oauth.py`). The mcp-use cloud connector and MCP inspector do dynamic client registration with redirect URIs under `manufact.com` (e.g. `https://manufact.com/oauth/callback`, `https://inspector.manufact.com/...`). `is_valid_redirect_uri` only allowed `claude.ai` / `claude.com` / `chatgpt.com` / `chat.openai.com`, so those registrations were rejected with `invalid_redirect_uri`. Adds a domain-suffix allowlist matching the apex and any subdomain, https-only. Exact-host matching is preserved, so look-alikes (`evilmanufact.com`, `manufact.com.evil.com`) and non-https stay rejected.

**2. Serve protected-resource metadata at the path-aware URL** (`lambda_function.py`). Per [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728), the protected-resource metadata for the `…/mcp` resource lives at `/.well-known/oauth-protected-resource/mcp` (the path is inserted after the well-known segment). The handler only matched the bare `/.well-known/oauth-protected-resource`, so the path-aware URL fell through to the auth gate → 401, breaking discovery for spec-strict clients and proxies that advertise the path-aware URL. Now serves both forms.
